### PR TITLE
Expose TimestepElapsed resource as lib pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub use self::{
     common::{EntityPoint, EntityPoint2D, EntityPoint3D},
     plugin::SpatialPlugin,
     spatial_access::SpatialAccess,
+    resources_components::TimestepElapsed,
 };
 
 #[cfg(feature = "kdtree")]

--- a/src/resources_components.rs
+++ b/src/resources_components.rs
@@ -21,7 +21,20 @@ impl<T> MovementTracked<T> {
     }
 }
 
-/// Internal resource used for fixed timestep without repeats.
+/// Resource used for fixed timestep without repeats in the same frame (builtin timestep may run the system multiple times per frame).
+///
+/// To modify the timestep at runtime, a system like this can be used:
+/// ```rs
+/// fn update_timestep(
+///     mut step: ResMut<TimestepElapsed<NearestNeighbourMarker>>,
+/// ) {
+
+///     if some_condition {
+///         step.set_duration(Duration::from_millis(15)); // only update timestep every 15ms.
+///     }
+/// }
+/// ```
+/// `NearestNeighbourMarker` in this case refers to the (marker) component you also passed to the Plugin.
 #[derive(Default)]
 pub struct TimestepElapsed<TComp>(pub Timer, pub PhantomData<TComp>);
 


### PR DESCRIPTION
Do this in order for users to change the timer within TimestepElapsed if a user for example wants to change the frequency of updates for the NNTree.

There could be better ways of exposing this functionality to the user but this is a quick and easy way.