### PR TITLE
Change tracking of last position to a hashmap, use it for removals.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -17,7 +17,7 @@ where
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct EntityPoint<Unit>
 where
     Unit: PartialEq,

--- a/src/kdtree/common.rs
+++ b/src/kdtree/common.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
-use bevy::prelude::Resource;
+use bevy::prelude::{Entity, Resource, Vec3};
+use bevy::utils::HashMap;
 use kd_tree::{KdPoint, KdTree};
 
 use crate::plugin::SpatialPlugin;
@@ -11,6 +12,11 @@ where
     KDItem: KdPoint,
 {
     pub tree: KdTree<KDItem>,
+
+    /// Internal map from entity to the corresponding last position
+    /// (used to make sure that removal logic is correct, and to check for significant moves)
+    pub last_pos_map: HashMap<Entity, Vec3>,
+
     pub component_type: PhantomData<TComp>,
 }
 
@@ -25,6 +31,7 @@ where
 
         KDTreeAccess {
             tree,
+            last_pos_map: Default::default(),
             component_type: PhantomData,
         }
     }

--- a/src/kdtree/kdtree2d/kdtree.rs
+++ b/src/kdtree/kdtree2d/kdtree.rs
@@ -29,7 +29,6 @@ where
     /// Due to kd-tree not supporting modification, this recreates the tree with all entities.
     fn update_tree(
         &mut self,
-        mut _commands: Commands,
         query: Query<TrackedQuery<Self::TComp>, With<Self::TComp>>,
     ) {
         let _span = info_span!("add-added").entered();
@@ -91,7 +90,10 @@ where
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
         let _span_d = info_span!("collect-data").entered();
-        let data: Vec<EntityPoint2D> = { all.iter().map(|e| e.into()).collect() };
+        let data: Vec<EntityPoint2D> = { all.iter().map(|e| {
+            self.last_pos_map.insert(e.1, e.0);
+            e.into()
+        }).collect() };
         _span_d.exit();
         let _span = info_span!("recreate").entered();
         #[cfg(not(target_arch = "wasm32"))]
@@ -136,5 +138,10 @@ where
     /// Always zero due to kd-tree being recreated every frame.
     fn get_recreate_after(&self) -> usize {
         0
+    }
+
+    /// Get last tracked position of an entity
+    fn get_last_pos(&self, entity: Entity) -> Option<&Vec3> {
+        self.last_pos_map.get(&entity)
     }
 }

--- a/src/kdtree/kdtree2d/kdtree.rs
+++ b/src/kdtree/kdtree2d/kdtree.rs
@@ -27,10 +27,7 @@ where
     /// Add entities to kd-tree, from bevy query. Used internally and called from a system.
     ///
     /// Due to kd-tree not supporting modification, this recreates the tree with all entities.
-    fn update_tree(
-        &mut self,
-        query: Query<TrackedQuery<Self::TComp>, With<Self::TComp>>,
-    ) {
+    fn update_tree(&mut self, query: Query<TrackedQuery<Self::TComp>, With<Self::TComp>>) {
         let _span = info_span!("add-added").entered();
         let all: Vec<(Vec3, Entity)> = query
             .iter()
@@ -90,10 +87,14 @@ where
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
         let _span_d = info_span!("collect-data").entered();
-        let data: Vec<EntityPoint2D> = { all.iter().map(|e| {
-            self.last_pos_map.insert(e.1, e.0);
-            e.into()
-        }).collect() };
+        let data: Vec<EntityPoint2D> = {
+            all.iter()
+                .map(|e| {
+                    self.last_pos_map.insert(e.1, e.0);
+                    e.into()
+                })
+                .collect()
+        };
         _span_d.exit();
         let _span = info_span!("recreate").entered();
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/rtree/common.rs
+++ b/src/rtree/common.rs
@@ -1,9 +1,10 @@
 use std::marker::PhantomData;
 
-use bevy::prelude::Resource;
+use bevy::prelude::{Entity, Resource, Vec3};
+use bevy::utils::HashMap;
 use rstar::{RTree, RTreeObject, RTreeParams};
 
-use crate::{common::EntityPoint, plugin::SpatialPlugin};
+use crate::{common::EntityPoint, plugin::SpatialPlugin, SpatialAccess};
 
 #[derive(Resource)]
 pub struct RTreeAccess<TComp, RObj, Params>
@@ -18,9 +19,14 @@ where
     /// The distance after which a entity is updated in the tree
     pub min_moved: f32,
 
+    /// Internal map from entity to the corresponding last position
+    /// (used to make sure that removal logic is correct, and to check for significant moves)
+    pub last_pos_map: HashMap<Entity, Vec3>,
+
     #[doc(hidden)]
     pub component_type: PhantomData<TComp>,
 }
+
 
 impl<TComp, RObj, Params> From<SpatialPlugin<TComp, RTreeAccess<TComp, RObj, Params>>>
     for RTreeAccess<TComp, RObj, Params>
@@ -35,16 +41,8 @@ where
             tree,
             min_moved: plugin.min_moved,
             recreate_after: plugin.recreate_after,
+            last_pos_map: Default::default(),
             component_type: PhantomData,
         }
-    }
-}
-
-impl<Unit> PartialEq for EntityPoint<Unit>
-where
-    Unit: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.entity == other.entity
     }
 }

--- a/src/rtree/common.rs
+++ b/src/rtree/common.rs
@@ -27,7 +27,6 @@ where
     pub component_type: PhantomData<TComp>,
 }
 
-
 impl<TComp, RObj, Params> From<SpatialPlugin<TComp, RTreeAccess<TComp, RObj, Params>>>
     for RTreeAccess<TComp, RObj, Params>
 where

--- a/src/rtree/rtree2d.rs
+++ b/src/rtree/rtree2d.rs
@@ -56,7 +56,10 @@ where
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
         let _span_d = info_span!("collect-data").entered();
-        let data: Vec<EntityPoint2D> = all.iter().map(|e| e.into()).collect();
+        let data: Vec<EntityPoint2D> = all.iter().map(|e| {
+            self.last_pos_map.insert(e.1, e.0);
+            e.into()
+        }).collect();
         _span_d.exit();
         let _span = info_span!("recreate").entered();
         let tree: RTree<EntityPoint2D, Params> = RTree::bulk_load_with_params(data);
@@ -67,7 +70,8 @@ where
     ///
     /// Only use if manually updating, the plugin will overwrite changes.
     fn add_point(&mut self, point: (Vec3, Entity)) {
-        self.tree.insert(point.into())
+        self.last_pos_map.insert(point.1, point.0);
+        self.tree.insert(point.into());
     }
 
     /// Removes a point from the tree.
@@ -81,7 +85,9 @@ where
     ///
     /// Only use if manually updating, the plugin will overwrite changes.
     fn remove_entity(&mut self, entity: Entity) -> bool {
-        self.tree.remove(&entity.into()).is_some()
+        // safe to unwrap because we only remove entities that have been previously added
+        let last_pos = self.last_pos_map.remove(&entity).unwrap();
+        self.tree.remove(&(last_pos, entity).into()).is_some()
     }
 
     /// Size of the tree
@@ -98,7 +104,13 @@ where
     fn get_recreate_after(&self) -> usize {
         self.recreate_after
     }
+
+    /// Get last tracked position of an entity
+    fn get_last_pos(&self, entity: Entity) -> Option<&Vec3> {
+        self.last_pos_map.get(&entity)
+    }
 }
+
 
 impl RTreeObject for EntityPoint2D {
     type Envelope = AABB<[f32; 2]>;

--- a/src/rtree/rtree2d.rs
+++ b/src/rtree/rtree2d.rs
@@ -56,10 +56,13 @@ where
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
         let _span_d = info_span!("collect-data").entered();
-        let data: Vec<EntityPoint2D> = all.iter().map(|e| {
-            self.last_pos_map.insert(e.1, e.0);
-            e.into()
-        }).collect();
+        let data: Vec<EntityPoint2D> = all
+            .iter()
+            .map(|e| {
+                self.last_pos_map.insert(e.1, e.0);
+                e.into()
+            })
+            .collect();
         _span_d.exit();
         let _span = info_span!("recreate").entered();
         let tree: RTree<EntityPoint2D, Params> = RTree::bulk_load_with_params(data);
@@ -110,7 +113,6 @@ where
         self.last_pos_map.get(&entity)
     }
 }
-
 
 impl RTreeObject for EntityPoint2D {
     type Envelope = AABB<[f32; 2]>;

--- a/src/rtree/rtree3d.rs
+++ b/src/rtree/rtree3d.rs
@@ -52,7 +52,10 @@ where
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
         let tree: RTree<EntityPoint3D, Params> =
-            RTree::bulk_load_with_params(all.iter().map(|e| e.into()).collect());
+            RTree::bulk_load_with_params(all.iter().map(|e| {
+                self.last_pos_map.insert(e.1, e.0);
+                e.into()
+            }).collect());
         self.tree = tree;
     }
 
@@ -60,7 +63,8 @@ where
     ///
     /// Only use if manually updating, the plugin will overwrite changes.
     fn add_point(&mut self, point: (Vec3, Entity)) {
-        self.tree.insert(point.into())
+        self.last_pos_map.insert(point.1, point.0);
+        self.tree.insert(point.into());
     }
 
     /// Adds a point to the tree.
@@ -74,7 +78,9 @@ where
     ///
     /// Only use if manually updating, the plugin will overwrite changes.
     fn remove_entity(&mut self, entity: Entity) -> bool {
-        self.tree.remove(&entity.into()).is_some()
+        // safe to unwrap because we only remove entities that have been previously added
+        let last_pos = self.last_pos_map.remove(&entity).unwrap();
+        self.tree.remove(&(last_pos, entity).into()).is_some()
     }
 
     /// Size of the tree
@@ -90,6 +96,11 @@ where
     /// Get the amount of entities which moved per frame after which the tree is fully recreated instead of updated.
     fn get_recreate_after(&self) -> usize {
         self.recreate_after
+    }
+
+    /// Get last tracked position of an entity
+    fn get_last_pos(&self, entity: Entity) -> Option<&Vec3> {
+        self.last_pos_map.get(&entity)
     }
 }
 

--- a/src/rtree/rtree3d.rs
+++ b/src/rtree/rtree3d.rs
@@ -51,11 +51,14 @@ where
     ///
     /// Only use if manually updating, the plugin will overwrite changes.
     fn recreate(&mut self, all: Vec<(Vec3, Entity)>) {
-        let tree: RTree<EntityPoint3D, Params> =
-            RTree::bulk_load_with_params(all.iter().map(|e| {
-                self.last_pos_map.insert(e.1, e.0);
-                e.into()
-            }).collect());
+        let tree: RTree<EntityPoint3D, Params> = RTree::bulk_load_with_params(
+            all.iter()
+                .map(|e| {
+                    self.last_pos_map.insert(e.1, e.0);
+                    e.into()
+                })
+                .collect(),
+        );
         self.tree = tree;
     }
 

--- a/src/spatial_access.rs
+++ b/src/spatial_access.rs
@@ -31,10 +31,7 @@ where
     /// the whole data structure gets re-created from scratch.
     ///
     /// Used internally and called from a system.
-    fn update_tree(
-        &mut self,
-        mut query: Query<TrackedQuery<Self::TComp>, With<Self::TComp>>,
-    ) {
+    fn update_tree(&mut self, mut query: Query<TrackedQuery<Self::TComp>, With<Self::TComp>>) {
         // get added entities, and add a MovementTracker
         let added_dist =
             info_span!("compute_added_entities", name = "compute_added_entities").entered();
@@ -63,8 +60,8 @@ where
                     }
                     // safe to unwrap because we only deal with entities that have been previously added
                     let last_pos = self.get_last_pos(e.entity).unwrap();
-                    return self.distance_squared( e.transform.translation, *last_pos
-                    ) >= self.get_min_dist().powi(2);
+                    return self.distance_squared(e.transform.translation, *last_pos)
+                        >= self.get_min_dist().powi(2);
                 }
                 false
             })
@@ -83,7 +80,9 @@ where
             recreate.exit();
         } else {
             let update = info_span!("partial_update", name = "partial_update").entered();
-            added.into_iter().for_each(|(curpos, entity)| self.add_point((curpos, entity)));
+            added
+                .into_iter()
+                .for_each(|(curpos, entity)| self.add_point((curpos, entity)));
             moved.into_iter().for_each(|(curpos, entity)| {
                 if self.remove_entity(entity) {
                     self.add_point((curpos, entity));

--- a/src/spatial_access.rs
+++ b/src/spatial_access.rs
@@ -63,7 +63,7 @@ where
                     }
                     // safe to unwrap because we only deal with entities that have been previously added
                     let last_pos = self.get_last_pos(e.entity).unwrap();
-                    return self.distance_squared( e.transform.translation, last_pos
+                    return self.distance_squared( e.transform.translation, *last_pos
                     ) >= self.get_min_dist().powi(2);
                 }
                 false
@@ -127,7 +127,7 @@ where
     /// Get the amount of moved/changed/added entities after which to perform a full recreate.
     fn get_recreate_after(&self) -> usize;
     /// Get last tracked position of an entity
-    fn get_last_pos(&self, entity: Entity) -> Option<Vec3>;
+    fn get_last_pos(&self, entity: Entity) -> Option<&Vec3>;
 }
 
 pub fn update_tree<SAcc>(


### PR DESCRIPTION
This PR aims to fix https://github.com/laundmo/bevy-spatial/issues/11 

Changes:
- remove RemovedTracker component and instead use a global hashmap from entity -> envelope (in our case a Vec3 is the envelope)
- update the `add_point`/`remove_point` function to update the last_pos position and use it to run removal correctly