### PR TITLE
Update to Bevy 0.15.0-rc3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 authors = ["laundmo"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false }
+bevy = { version = "0.15.0-rc.3", default-features = false }
 # KD-Tree dependencies
 kd-tree = { version = "0.6", optional = true, features = ["rayon"] }
 typenum = { version = "1.17.0" }
@@ -23,7 +23,8 @@ default = ["kdtree"]
 kdtree = ["dep:kd-tree"]
 
 [dev-dependencies]
-bevy = { version = "0.14" }
+bevy = { version = "0.15.0-rc.3" }
+
 rand = "0.8.5"
 wasm-server-runner = "0.6"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,7 @@
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-notice = "deny"
-unsound = "deny"
 ignore = [
     "RUSTSEC-2020-0056", # from xml-rs 0.8.4 - unmaintained - it's used in a build script of winit
 ]
-
-[licenses]
-unlicensed = "deny"
-copyleft = "deny"
-allow-osi-fsf-free = "either"
-default = "deny"
 
 [[licenses.clarify]]
 name = "stretch"

--- a/examples/distance2d.rs
+++ b/examples/distance2d.rs
@@ -51,19 +51,16 @@ fn main() {
 type NNTree = KDTree2<NearestNeighbourComponent>;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
     commands.spawn((
         Cursor,
-        SpriteBundle {
-            sprite: Sprite {
-                color: Color::srgb(0.0, 0.0, 1.0),
-                custom_size: Some(Vec2::new(10.0, 10.0)),
-                ..default()
-            },
-            transform: Transform {
-                translation: Vec3::ZERO,
-                ..default()
-            },
+        Sprite {
+            color: Color::srgb(0.0, 0.0, 1.0),
+            custom_size: Some(Vec2::new(10.0, 10.0)),
+            ..default()
+        },
+        Transform {
+            translation: Vec3::ZERO,
             ..default()
         },
     ));
@@ -76,12 +73,9 @@ fn setup(mut commands: Commands) {
         for y in -100..100 {
             commands.spawn((
                 NearestNeighbourComponent,
-                SpriteBundle {
-                    sprite: sprite.clone(),
-                    transform: Transform {
-                        translation: Vec3::new((x * 4) as f32, (y * 4) as f32, 0.0),
-                        ..default()
-                    },
+                sprite.clone(),
+                Transform {
+                    translation: Vec3::new((x * 4) as f32, (y * 4) as f32, 0.0),
                     ..default()
                 },
             ));
@@ -101,7 +95,7 @@ fn update_mouse_pos(
     let win = window.single();
     let (cam, cam_t) = cam.single();
     if let Some(w_pos) = win.cursor_position() {
-        if let Some(pos) = cam.viewport_to_world_2d(cam_t, w_pos) {
+        if let Ok(pos) = cam.viewport_to_world_2d(cam_t, w_pos) {
             mouse.pos = pos;
         }
     }

--- a/examples/modify_timestep.rs
+++ b/examples/modify_timestep.rs
@@ -29,28 +29,25 @@ fn main() {
 type NNTree = KDTree2<NearestNeighbour>;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    commands.spawn(TextBundle::from_section(
-        "Click mouse to change rate",
-        TextStyle {
+    commands.spawn((
+        Text("Click mouse to change rate".to_string()),
+        TextFont {
             font_size: 30.0,
-            color: Color::BLACK,
             ..default()
         },
+        TextColor(Color::BLACK),
     ));
 
     commands.spawn((
         Chaser,
-        SpriteBundle {
-            sprite: Sprite {
-                color: csscolors::BLUE.into(),
-                custom_size: Some(Vec2::new(10.0, 10.0)),
-                ..default()
-            },
-            transform: Transform::from_translation(Vec3::ZERO),
+        Sprite {
+            color: csscolors::BLUE.into(),
+            custom_size: Some(Vec2::new(10.0, 10.0)),
             ..default()
         },
+        Transform::from_translation(Vec3::ZERO),
     ));
 
     let neighbours = [
@@ -63,15 +60,12 @@ fn setup(mut commands: Commands) {
     for (color, position) in neighbours {
         commands.spawn((
             NearestNeighbour,
-            SpriteBundle {
-                sprite: Sprite {
-                    color: Color::from(color),
-                    custom_size: Some(Vec2::new(10.0, 10.0)),
-                    ..default()
-                },
-                transform: Transform::from_translation(position),
+            Sprite {
+                color: Color::from(color),
+                custom_size: Some(Vec2::new(10.0, 10.0)),
                 ..default()
             },
+            Transform::from_translation(position),
         ));
     }
 }
@@ -93,7 +87,7 @@ fn move_to(
     for mut transform in &mut query {
         if let Some(nearest) = treeaccess.nearest_neighbour(transform.translation.truncate()) {
             let towards = nearest.0.extend(0.0) - transform.translation;
-            transform.translation += towards.normalize() * time.delta_seconds() * 350.0;
+            transform.translation += towards.normalize() * time.delta_secs() * 350.0;
         }
     }
 }
@@ -112,8 +106,8 @@ fn mouseclick(
     if mouse_input.just_pressed(MouseButton::Left) {
         let duration = step.get_duration();
         step.set_duration(*other_duration);
-        text.single_mut().sections[0].value = format!(
-            "Spatial Update Rate: every {}ms",
+        text.single_mut().0 = format!(
+            "Spatial Update Rate: {} ms",
             other_duration.as_millis()
         );
         *other_duration = duration;

--- a/examples/movetowards.rs
+++ b/examples/movetowards.rs
@@ -1,6 +1,5 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
-    ecs::query,
     math::vec2,
     prelude::*,
     time::common_conditions::on_timer,
@@ -26,7 +25,7 @@ fn main() {
                 .with_frequency(Duration::from_secs(1))
                 .with_transform(TransformMode::Transform),
         )
-        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(LogDiagnosticsPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(
@@ -43,21 +42,18 @@ fn main() {
 type NNTree = KDTree3<NearestNeighbour>;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
     for x in -6..6 {
         for y in -6..6 {
             commands.spawn((
                 NearestNeighbour,
-                SpriteBundle {
-                    sprite: Sprite {
-                        color: Color::srgb(0.7, 0.3, 0.5),
-                        custom_size: Some(Vec2::new(10.0, 10.0)),
-                        ..default()
-                    },
-                    transform: Transform {
-                        translation: Vec3::new((x * 100) as f32, (y * 100) as f32, 0.0),
-                        ..default()
-                    },
+                Sprite {
+                    color: Color::srgb(0.7, 0.3, 0.5),
+                    custom_size: Some(Vec2::new(10.0, 10.0)),
+                    ..default()
+                },
+                Transform {
+                    translation: Vec3::new((x * 100) as f32, (y * 100) as f32, 0.0),
                     ..default()
                 },
             ));
@@ -79,22 +75,19 @@ fn mouseclick(
                 for yoff in -1..=1 {
                     commands.spawn((
                         MoveTowards,
-                        SpriteBundle {
-                            sprite: Sprite {
-                                color: Color::srgb(0.15, 0.15, 1.0),
-                                custom_size: Some(Vec2::new(10.0, 10.0)),
-                                ..default()
-                            },
-                            transform: Transform {
-                                translation: cam
-                                    .viewport_to_world_2d(
-                                        cam_t,
-                                        pos + vec2(xoff as f32 * 16., yoff as f32 * 16.),
-                                    )
-                                    .unwrap_or(Vec2::ZERO)
-                                    .extend(0.0),
-                                ..default()
-                            },
+                        Sprite {
+                            color: Color::srgb(0.15, 0.15, 1.0),
+                            custom_size: Some(Vec2::new(10.0, 10.0)),
+                            ..default()
+                        },
+                        Transform {
+                            translation: cam
+                                .viewport_to_world_2d(
+                                    cam_t,
+                                    pos + vec2(xoff as f32 * 16., yoff as f32 * 16.),
+                                )
+                                .unwrap_or(Vec2::ZERO)
+                                .extend(0.0),
                             ..default()
                         },
                     ));
@@ -112,7 +105,7 @@ fn move_to(
     for mut transform in &mut query {
         if let Some(nearest) = treeaccess.nearest_neighbour(transform.translation) {
             let towards = nearest.0 - transform.translation;
-            transform.translation += towards.normalize() * time.delta_seconds() * 64.0;
+            transform.translation += towards.normalize() * time.delta_secs() * 64.0;
         }
     }
 }

--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -28,7 +28,7 @@ macro_rules! kdtree_impl {
         /// Resource for storing a ``KdTree``
         #[derive(Resource)]
         pub struct $treename<Comp> {
-            /// The KdTree
+            /// The ``KdTree``
             pub tree: BaseKdTree<$pt>,
             component_type: PhantomData<Comp>,
         }


### PR DESCRIPTION
Also removed deprecated keys from deny.toml as per: https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md#0160---2024-08-02

The distance3d example now takes advantage of Bevy 0.15's automatic mesh instancing for meshes with the same material and mesh handles. This makes it perform significantly better so I added more cubes to that example to show that off.